### PR TITLE
Rename package from cachy to pycachy to align with PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "cachy"
+name = "pycachy"
 dynamic = ["version"]
 description = "Cache your API calls with a single line of code. No mocks, no fixtures. Just faster, cleaner code."
 readme = "README.md"


### PR DESCRIPTION
W the move to pyproject.toml I think this bug slipped in. The name in pyproject.toml should be the name on pypi.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#name

<img width="797" height="238" alt="image" src="https://github.com/user-attachments/assets/27790ead-d17d-4ecd-ad8a-68c57afabbb8" />
