### PR TITLE
norm_pats apply to the URL as well as the body

### DIFF
--- a/cachy/core.py
+++ b/cachy/core.py
@@ -98,7 +98,8 @@ def _norm_content(r):
 
 def _key(r, is_stream=False):
     "Create a unique, deterministic id from the request `r`."
-    return hashlib.sha256(f"{r.url.copy_remove_param('key')}{is_stream}".encode() + _normalize(_norm_content(r))).hexdigest()[:8]
+    url = _normalize(str(r.url.copy_remove_param('key')).encode()).decode()
+    return hashlib.sha256(f"{url}{is_stream}".encode() + _normalize(_norm_content(r))).hexdigest()[:8]
 
 # %% ../nbs/00_core.ipynb #4cf3ccd9
 def _is_text(res):

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -752,7 +752,8 @@
     "\n",
     "def _key(r, is_stream=False):\n",
     "    \"Create a unique, deterministic id from the request `r`.\"\n",
-    "    return hashlib.sha256(f\"{r.url.copy_remove_param('key')}{is_stream}\".encode() + _normalize(_norm_content(r))).hexdigest()[:8]"
+    "    url = _normalize(str(r.url.copy_remove_param('key')).encode()).decode()\n",
+    "    return hashlib.sha256(f\"{url}{is_stream}\".encode() + _normalize(_norm_content(r))).hexdigest()[:8]"
    ]
   },
   {
@@ -760,7 +761,7 @@
    "id": "107e77e3",
    "metadata": {},
    "source": [
-    "`norm_pats` is public: append your own `(pattern, replacement)` pairs (strings or compiled) to normalize app-specific ephemeral content out of the cache key. For example solveit embeds random message ids in its requests, so its tests do `norm_pats.append((r'\\b_[0-9a-f]{8}\\b', '_MSGID'))` -- re-running a test with fresh ids then still hits the cache. Only the key is affected; responses are stored as-is (see `resp_norm_pats` above for the stored side)."
+    "`norm_pats` is public: append your own `(pattern, replacement)` pairs (strings or compiled) to normalize app-specific ephemeral content out of the cache key. For example solveit embeds random message ids in its requests, so its tests do `norm_pats.append((r'\\b_[0-9a-f]{8}\\b', '_MSGID'))` -- re-running a test with fresh ids then still hits the cache. The patterns apply to the URL as well as the body, so a pattern over the port lets a test replay against whichever local port serves. Only the key is affected; responses are stored as-is (see `resp_norm_pats` above for the stored side)."
    ]
   },
   {
@@ -774,6 +775,28 @@
     "c2 = b'{\"messages\":[{\"role\":\"user\",\"content\":\"Say hello in French\"}],\"model\":\"kimi-k2.5\",\"max_tokens\":64,\"temperature\":1.0}'\n",
     "test_eq(_norm_content(SimpleNamespace(headers={'content-type': 'application/json'}, content=c1, _content='done reading')), \n",
     "        _norm_content(SimpleNamespace(headers={'content-type': 'application/json'}, content=c2, _content='done reading')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37416719",
+   "metadata": {},
+   "source": [
+    "A port in the URL is the same kind of ephemeral detail: two requests to different local ports key alike once a pattern maps the port, and the pattern comes off again so the rest of the page keys as before:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe17f006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "norm_pats.append((r'localhost:\\d+', 'localhost:PORT'))\n",
+    "r1,r2 = [httpx.Request('POST', f'http://localhost:{p}/x', json={'q': 1}) for p in (5012, 5013)]\n",
+    "test_eq(_key(r1), _key(r2))\n",
+    "norm_pats.pop()\n",
+    "_key(r1)"
    ]
   },
   {


### PR DESCRIPTION
The cache key normalises the request URL with the same `norm_pats` it applies to the body, so a pattern over an ephemeral URL detail, such as the port of a local server under test, lets a recording replay wherever that server runs. Keys of requests whose URL matches an existing pattern change once. See the `norm_pats` lesson in the core notebook.